### PR TITLE
Fixed units not showing and laps not showing also.

### DIFF
--- a/Aim_2_MoTeC/Program.cs
+++ b/Aim_2_MoTeC/Program.cs
@@ -8,6 +8,10 @@ namespace Aim_2_MoTeC
         [STAThread]
         static void Main()
         {
+            //Globalization set to neutral language
+            Thread.CurrentThread.CurrentCulture = new System.Globalization.CultureInfo("en");
+            Thread.CurrentThread.CurrentUICulture = new System.Globalization.CultureInfo("en");
+
             Application.SetHighDpiMode(HighDpiMode.SystemAware);
             Application.EnableVisualStyles();
             Application.SetCompatibleTextRenderingDefault(false);

--- a/Aim_2_MoTeC/ldParser.cs
+++ b/Aim_2_MoTeC/ldParser.cs
@@ -341,8 +341,9 @@ namespace Aim_2_MoTeC
             f.Write(scale);
             f.Write(dec);
             f.Write(nameBytes);
-            f.Write(unitBytes);
             f.Write(shortNameBytes);
+            f.Write(unitBytes);
+
 
             f.Write((byte)201);
             f.Write(new byte[39]);


### PR DESCRIPTION
Changed the order of writing shortNameBytes and unitBytes to ensure u…nits display correctly in MoTeC. Additionally,set the globalization configuration to English to prevent glitches with number formatting in countries where commas are used instead of dots.